### PR TITLE
a few changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,8 @@ FROM mambaorg/micromamba:2.0.8 AS micromamba
 FROM ghcr.io/nextsimhub/nextsimdg-dev-env:latest
 
 ## build nextsimdg model
-RUN git clone https://github.com/nextsimhub/nextsimdg.git /home/nextsimdg
+RUN git clone -b issue375_polynya_working https://github.com/nextsimhub/nextsimdg.git /home/nextsimdg
 WORKDIR /home/nextsimdg
-RUN git checkout 82947a0b750d30e975dddefee806e1c1706ac32e
 
 WORKDIR /home/nextsimdg/build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ FROM ghcr.io/nextsimhub/nextsimdg-dev-env:latest
 
 ## build nextsimdg model
 RUN git clone -b issue375_polynya_working https://github.com/nextsimhub/nextsimdg.git /home/nextsimdg
-WORKDIR /home/nextsimdg
 
 WORKDIR /home/nextsimdg/build
 
@@ -14,7 +13,7 @@ ARG mpi=OFF
 ARG xios=OFF
 ARG jobs=1
 
-RUN . /opt/spack-environment/activate.sh && cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_MPI=$mpi -DENABLE_XIOS=$xios -Dxios_DIR=/xios .. && make -j $jobs
+RUN . /opt/spack-environment/activate.sh && cmake -DCMAKE_BUILD_TYPE=Release -DWITH_THREADS=ON -DENABLE_MPI=$mpi -DENABLE_XIOS=$xios -Dxios_DIR=/xios .. && make -j $jobs
 
 ##install libraries with mamba
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM mambaorg/micromamba:2.0.8 AS micromamba
 FROM ghcr.io/nextsimhub/nextsimdg-dev-env:latest
 
 ## build nextsimdg model
-RUN git clone -b issue375_polynya_working https://github.com/nextsimhub/nextsimdg.git /home/nextsimdg
+RUN git clone -b workshop_brown https://github.com/nextsimhub/nextsimdg.git /home/nextsimdg
 
 WORKDIR /home/nextsimdg/build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 # Micromamba container
-
-FROM mambaorg/micromamba:2.0.8 as micromamba
+FROM mambaorg/micromamba:2.0.8 AS micromamba
 
 # Final container
 FROM ghcr.io/nextsimhub/nextsimdg-dev-env:latest
 
 ## build nextsimdg model
 RUN git clone https://github.com/nextsimhub/nextsimdg.git /home/nextsimdg
+WORKDIR /home/nextsimdg
+RUN git checkout 82947a0b750d30e975dddefee806e1c1706ac32e
 
 WORKDIR /home/nextsimdg/build
 
@@ -16,11 +17,7 @@ ARG jobs=1
 
 RUN . /opt/spack-environment/activate.sh && cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_MPI=$mpi -DENABLE_XIOS=$xios -Dxios_DIR=/xios .. && make -j $jobs
 
-##install nedas
-RUN git clone -b develop https://github.com/nansencenter/NEDAS.git /home/NEDAS
-
 ##install libraries with mamba
-
 USER root
 
 ARG MAMBA_USER=mambauser
@@ -45,7 +42,6 @@ USER $MAMBA_USER
 SHELL ["/usr/local/bin/_dockerfile_shell.sh"]
 
 ENTRYPOINT ["/usr/local/bin/_entrypoint.sh"]
-CMD ["/bin/bash"]
 
 COPY --chown=$MAMBA_USER:$MAMBA_USER environment.yml /tmp/environment.yml
 RUN micromamba install -y -n base -f /tmp/environment.yml && \
@@ -62,6 +58,7 @@ RUN apt-get -y -q update \
 	libboost-log1.74 \
 	libboost-program-options1.74 \
 	libeigen3-dev \
+    mpich libmpich-dev \
 	netcdf-bin \
         vim \
 	wget \


### PR DESCRIPTION
- nextsimdg model source code is rapidly developed now, the latest version doesn't work well with the demo case, so use a fixed Apr 15 version instead

- adding mpich in the image to enable mpi for DA code

- removing the installation of NEDAS package for now, it is also rapidly developed, so I instead include the package as part of the data, to be downloaded along with test data.